### PR TITLE
Slimmed down rendering of TurtleScreens & Turtles.

### DIFF
--- a/src/Color.hpp
+++ b/src/Color.hpp
@@ -820,11 +820,19 @@ namespace cturtle{
                  Initializes this color to white. (all components 255)*/
         Color(){r = g = b = 255;}
         
-        /*\brief Returns a pointer to the first component of this color.
+        /**\brief Returns a pointer to the first component of this color.
                  This is useful for functions which require color as an input array.
           Returns a read-only pointer to the elements, in sequential order.*/
         const component_t* const rgbPtr() const{
             return &r;
+        }
+        
+        /**\brief Assigns R, G, and B values to the specified pointer.
+         * Must contain enough valid space at dest to hold 3 bytes.*/
+        void assignAt(component_t* dest) const{
+            dest[0] = r;
+            dest[1] = g;
+            dest[2] = b;
         }
         
         /*TODO: Document Me*/

--- a/src/Geometry.hpp
+++ b/src/Geometry.hpp
@@ -617,6 +617,9 @@ namespace cturtle {
     void drawLine(Image& imgRef, int x1, int y1, int x2, int y2, Color c, unsigned int width){
         if (x1 == x2 && y1 == y2) {
             return;
+        }else if(width == 1){
+            imgRef.draw_line(x1,y1,x2,y2,c.rgbPtr());
+            return;
         }
         const double xoffs = std::abs(x1 - x2);
         const double yoffs = std::abs(y1 - y2);


### PR DESCRIPTION
 - Brought common screen draw complexity to O(1) from O(n)
	- Only O(n) when canvas contents have been invalidated.
 - Turtles keep iterators to where their fill geometry is to be stored
	  to maintain simplicity and expected behavior.
 - Removed swap()/swapDisplay() functions in TurtleScreen; no longer needed.